### PR TITLE
Add ability to strip all emoji from a string

### DIFF
--- a/lib/exmoji/scanner.ex
+++ b/lib/exmoji/scanner.ex
@@ -85,4 +85,21 @@ defmodule Exmoji.Scanner do
   # when we reach the end, return reversed accumulator.
   defp _bscan(<<>>, acc), do: Enum.reverse(acc)
 
+  @doc """
+  Strip out all emoji from the string
+  """
+  def strip_emoji(str) do
+    do_strip(str, <<>>)
+  end
+
+  # define functions that pattern match against each emojichar binary at head.
+  for glyph <- sorted_chars do
+    defp do_strip(<<unquote(glyph), tail::binary >>, acc) do
+      do_strip(tail, acc)
+    end
+  end
+  defp do_strip(<< head::utf8, tail::binary >>, acc) do
+    do_strip(tail, acc <> <<head::utf8>>)
+  end
+  defp do_strip(<<>>, acc), do: acc
 end

--- a/test/scanner_test.exs
+++ b/test/scanner_test.exs
@@ -56,4 +56,15 @@ defmodule ScannerTest do
     assert Scanner.scan(@case_none) == []
   end
 
+  test ".strip" do
+    assert Scanner.strip_emoji(@case_exact) == ""
+    assert Scanner.strip_emoji(@case_multi) == ""
+    assert Scanner.strip_emoji(@case_variant) == "flying on my  to visit the  people."
+    assert Scanner.strip_emoji(@case_multivariant) == "first a  then a "
+    assert Scanner.strip_emoji(@case_duplicates) == "flying my  to visit the  people who have their own  omg!"
+    assert Scanner.strip_emoji(@case_none) == "i like turtles"
+
+    foreign1 = "طويلبون فيلادلفيا"
+    assert Scanner.strip_emoji(foreign1) == foreign1
+  end
 end


### PR DESCRIPTION
I initially wanted to provide a scan-type method that would return a list of both emoji's and strings but it ended up taking too long. Plus the strings we're using this for are short so parsing them twice shouldn't be a big deal.